### PR TITLE
configure requires well added to Makefile.PL and META.* files

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -46,18 +46,20 @@ if ( MyInstallUtil::need_xvfb() and not MyInstallUtil::can_xvfb() ) {
       . "Please install xvfb.";
 }
 
-configure {
-    'Capture::Tiny'         => 0,
-    'File::Which'           => 0,
-    'Path::Tiny'            => 0,
-    'File::Copy::Recursive' => 0,
-};
+
 
 plugin 'Probe::CommandLine' => (
     command => MyInstallUtil::wrap_orca('orca'),
     args    => ['-h'],
     match   => qr/plotly/i,
 );
+
+configure {
+    requires 'Capture::Tiny'         => 0;
+    requires 'File::Which'           => 0;
+    requires 'Path::Tiny'            => 0;
+    requires 'File::Copy::Recursive' => 0;
+};
 
 share {
     require Path::Tiny;


### PR DESCRIPTION
Hello :smile: 

I have trouble to install Alien::Plotly::Orca due to a prereq issue (see this [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/658912736?check_suite_focus=true).

I propose this change, that adds well the configure requires to Makefile.PL and META.*.

It's probably a bit overkill and we could also imagine changing the `require File::Copy::Recursive` per `requires 'File::Copy::Recursive' => '0';` in the share block (here : https://github.com/thibaultduponchelle/perl5-Alien-Plotly-Orca/blob/master/alienfile#L102)  and also the same for `Path::Tiny` but configure requires is working fine :) 

/cc @plicease

Best regards.

Thibault